### PR TITLE
Working on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build/
 CMakeLists.txt.user
 *.swp
+mingw
+linux
+vs
+macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(NOT MSVC)
-    set(CMAKE_CXX_FLAGS "-Wall -Werror -Wno-unused-variable -std=c++11 ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-Wall -Wno-unused-variable -std=c++11 ${CMAKE_CXX_FLAGS}")
 else()
     add_definitions(-D_WEBSOCKETPP_CPP11_CHRONO_)
 endif()

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -7,7 +7,8 @@ set_target_properties(bonefish_bin PROPERTIES OUTPUT_NAME bonefish)
 add_dependencies(bonefish_bin bonefish)
 
 if (WIN32)
-    target_link_libraries(bonefish_bin ws2_32)
+    target_link_libraries(bonefish_bin PRIVATE ws2_32)
+    target_compile_definitions(bonefish_bin PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)
 endif()
 
 target_link_libraries(bonefish_bin

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -6,6 +6,10 @@ set_target_properties(bonefish_bin PROPERTIES OUTPUT_NAME bonefish)
 
 add_dependencies(bonefish_bin bonefish)
 
+if (WIN32)
+    target_link_libraries(bonefish_bin ws2_32)
+endif()
+
 target_link_libraries(bonefish_bin
     bonefish
     ${Boost_LIBRARIES}

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -88,11 +88,13 @@ daemon::daemon(const daemon_options& options)
                     m_io_service, boost::asio::ip::address(), options.rawsocket_port());
             m_rawsocket_server->attach_listener(std::static_pointer_cast<rawsocket_listener>(listener));
         }
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
         if (!options.rawsocket_path().empty()) {
             auto listener = std::make_shared<uds_listener>(
                     m_io_service, options.rawsocket_path());
             m_rawsocket_server->attach_listener(std::static_pointer_cast<rawsocket_listener>(listener));
         }
+#endif
     }
 }
 

--- a/examples/integration.cpp
+++ b/examples/integration.cpp
@@ -60,13 +60,16 @@ int main(int argc, char** argv)
 
     std::shared_ptr<bonefish::rawsocket_server> rawsocket_server =
             std::make_shared<bonefish::rawsocket_server>(routers, serializers);
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
     std::shared_ptr<bonefish::uds_listener> uds_listener =
             std::make_shared<bonefish::uds_listener>(io_service, "/tmp/bonefish.sock");
+#endif
     std::shared_ptr<bonefish::tcp_listener> tcp_listener =
             std::make_shared<bonefish::tcp_listener>(io_service, boost::asio::ip::address(), 8888);
-
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
     rawsocket_server->attach_listener(
             std::static_pointer_cast<bonefish::rawsocket_listener>(uds_listener));
+#endif
     rawsocket_server->attach_listener(
             std::static_pointer_cast<bonefish::rawsocket_listener>(tcp_listener));
     rawsocket_server->start();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,7 +146,8 @@ set(PRIVATE_HEADERS
 add_library(bonefish STATIC ${SOURCES} ${PUBLIC_HEADERS} ${PRIVATE_HEADERS})
 
 if (WIN32)
-    target_link_libraries(bonefish ws2_32 Mswsock)
+    target_link_libraries(bonefish PRIVATE ws2_32 Mswsock)
+    target_compile_definitions(bonefish PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)
 endif()
 
 target_link_libraries(bonefish

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,10 @@ set(PRIVATE_HEADERS
 
 add_library(bonefish STATIC ${SOURCES} ${PUBLIC_HEADERS} ${PRIVATE_HEADERS})
 
+if (WIN32)
+    target_link_libraries(bonefish ws2_32 Mswsock)
+endif()
+
 target_link_libraries(bonefish
     ${Boost_LIBRARIES})
 

--- a/src/bonefish/broker/wamp_broker.cpp
+++ b/src/bonefish/broker/wamp_broker.cpp
@@ -108,7 +108,7 @@ void wamp_broker::detach_session(const wamp_session_id& session_id)
         const std::vector<std::unique_ptr<wamp_publish_message>>* testaments =
             session_itr->second->get_testaments_for_scope(scope);
 
-        if (testaments && not testaments->empty()) {
+        if (testaments && !testaments->empty()) {
             BONEFISH_TRACE("detach session: processing testaments for scope %1%", static_cast<int>(scope));
 
             for (const auto& testament : *testaments) {

--- a/src/bonefish/rawsocket/rawsocket_connection.hpp
+++ b/src/bonefish/rawsocket/rawsocket_connection.hpp
@@ -19,8 +19,11 @@
 
 #include <bonefish/common/wamp_connection_base.hpp>
 #include <bonefish/trace/trace.hpp>
-
+#ifdef __linux__
 #include <arpa/inet.h>
+#elif  _WIN32
+#include <WinSock2.h>
+#endif
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/system/error_code.hpp>

--- a/src/bonefish/rawsocket/uds_connection.hpp
+++ b/src/bonefish/rawsocket/uds_connection.hpp
@@ -17,12 +17,16 @@
 #ifndef BONEFISH_UDS_CONNECTION_HPP
 #define BONEFISH_UDS_CONNECTION_HPP
 
+#include <boost/asio.hpp>
+
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+
 #include <bonefish/rawsocket/rawsocket_connection.hpp>
 
-#include <boost/asio/buffer.hpp>
-#include <boost/asio/local/stream_protocol.hpp>
-#include <boost/asio/read.hpp>
-#include <boost/asio/write.hpp>
+//#include <boost/asio/buffer.hpp>
+//#include <boost/asio/local/stream_protocol.hpp>
+//#include <boost/asio/read.hpp>
+//#include <boost/asio/write.hpp>
 
 namespace bonefish {
 
@@ -80,4 +84,6 @@ inline void uds_connection::write(
 
 } // namespace bonefish
 
+
+#endif
 #endif // BONEFISH_UDS_CONNECTION_HPP

--- a/src/bonefish/rawsocket/uds_listener.cpp
+++ b/src/bonefish/rawsocket/uds_listener.cpp
@@ -17,6 +17,7 @@
 #include <bonefish/rawsocket/uds_listener.hpp>
 #include <bonefish/rawsocket/uds_connection.hpp>
 
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 #if !defined(_WIN32)
     #include <unistd.h>
 #endif
@@ -82,3 +83,6 @@ void uds_listener::async_accept()
 }
 
 } // namespace bonefish
+
+
+#endif

--- a/src/bonefish/rawsocket/uds_listener.cpp
+++ b/src/bonefish/rawsocket/uds_listener.cpp
@@ -17,7 +17,9 @@
 #include <bonefish/rawsocket/uds_listener.hpp>
 #include <bonefish/rawsocket/uds_connection.hpp>
 
-#include <unistd.h>
+#if !defined(_WIN32)
+    #include <unistd.h>
+#endif
 
 namespace bonefish {
 

--- a/src/bonefish/rawsocket/uds_listener.hpp
+++ b/src/bonefish/rawsocket/uds_listener.hpp
@@ -14,13 +14,15 @@
  *  limitations under the License.
  */
 
+#include <boost/asio.hpp>
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 #ifndef BONEFISH_UDS_LISTENER_HPP
 #define BONEFISH_UDS_LISTENER_HPP
 
 #include <bonefish/rawsocket/rawsocket_listener.hpp>
 
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/local/stream_protocol.hpp>
+//#include <boost/asio/io_service.hpp>
+//#include <boost/asio/local/stream_protocol.hpp>
 #include <memory>
 #include <string>
 
@@ -51,4 +53,5 @@ private:
 
 } // namespace bonefish
 
+#endif
 #endif // BONEFISH_UDS_LISTENER_HPP

--- a/src/bonefish/router/wamp_router_impl.cpp
+++ b/src/bonefish/router/wamp_router_impl.cpp
@@ -86,7 +86,12 @@ auth_requirement check_if_authentication_required(
     });
 
     if (i != requested.end()) {
-        return {*i != auth_type::anonymous, {.id = hello_details.get_auth_id(), .method = *i}};
+        auth_requirement aux{};
+        aux.required = *i != auth_type::anonymous;
+        aux.info.id = hello_details.get_auth_id();
+        aux.info.method = *i;
+        return aux;
+        //return { *i != auth_type::anonymous, {.id = hello_details.get_auth_id(), .method = *i} };
     } else {
         return {true, {}};  // failure case, challenge required, but couldn't match auth method
     }

--- a/test/functional/websocket/CMakeLists.txt
+++ b/test/functional/websocket/CMakeLists.txt
@@ -3,7 +3,8 @@ set(SOURCES client.cpp)
 add_executable(client ${SOURCES})
 
 if (WIN32)
-    target_link_libraries(client ws2_32)
+    target_link_libraries(client PRIVATE ws2_32)
+    target_compile_definitions(client PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)
 endif()
 
 target_link_libraries(client

--- a/test/functional/websocket/CMakeLists.txt
+++ b/test/functional/websocket/CMakeLists.txt
@@ -2,6 +2,10 @@ set(SOURCES client.cpp)
 
 add_executable(client ${SOURCES})
 
+if (WIN32)
+    target_link_libraries(client ws2_32)
+endif()
+
 target_link_libraries(client
     ${Boost_LIBRARIES}
     ${CMAKE_DL_LIBS}


### PR DESCRIPTION
With these changes bonefish compiles and works on Windows using MinGW and MSVC 2022
I had to remove -Werror option because modern GCC gives warnings on boost 